### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(TomoSAM)
 # Extension meta-information
 set(EXTENSION_HOMEPAGE "https://github.com/fsemerar/SlicerTomoSAM")
 set(EXTENSION_CATEGORY "Segmentation")
-set(EXTENSION_CONTRIBUTORS "Federico Semeraro (NASA); Alexandre Quintart (NASA); Sergio Fraile Izquierdo (NASA); Joseph Ferguson (Stanford University)")
+set(EXTENSION_CONTRIBUTORS "Federico Semeraro (NASA), Alexandre Quintart (NASA), Sergio Fraile Izquierdo (NASA), Joseph Ferguson (Stanford University)")
 set(EXTENSION_DESCRIPTION "TomoSAM helps with the segmentation of 3D data from tomography or other imaging techniques using the Segment Anything Model (SAM).")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/fsemerar/SlicerTomoSAM/main/TomoSAM/Resources/Media/tomosam_logo.png")
 set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/fsemerar/SlicerTomoSAM/main/TomoSAM/Resources/Media/tomosam_screenshot_1.png")


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.